### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/tigetflag.t
+++ b/t/tigetflag.t
@@ -20,7 +20,7 @@ use Test::File::ShareDir
 };
 #------------------------------------------------------
 BEGIN {
-    use_ok( 'MarpaX::Database::Terminfo::Interface', qw/:all/ ) || print "Bail out!\n";
+    use_ok( 'MarpaX::Database::Terminfo::Interface' ) || print "Bail out!\n";
 }
 my $t = MarpaX::Database::Terminfo::Interface->new();
 $t->tgetent('nsterm-16color');


### PR DESCRIPTION
MarpaX::Database::Terminfo::Interface does not export anything, so don't pass any arguments to use_ok. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.